### PR TITLE
[Fix] My Page 이동 수단 기본값 UI 표시 오류 수정

### DIFF
--- a/TAMINGO/Features/MyPage/TransportRank/View/TransportRankSettingView.swift
+++ b/TAMINGO/Features/MyPage/TransportRank/View/TransportRankSettingView.swift
@@ -138,7 +138,7 @@ struct TrafficSection: View {
 
                     RankLabel(
                         rank: rank,
-                        title: transport?.title ?? "Label"
+                        title: displayTitle(for: transport)
                     ) {
                         activePicker = .transport(rank: rank)
                     }
@@ -158,6 +158,11 @@ struct TrafficSection: View {
         .padding(16)
         .cardStyle()
     }
+    private func displayTitle(for type: TransportType?) -> String {
+        guard let type else { return "Label" }
+        return type == .none ? "Label" : type.title
+    }
+
 }
 
 private extension TransportRankSettingView {


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [x] 이동 수단 기본값 선택 시 Label(미선택 상태)로 표시되도록 수정

## 🛠️ 작업내용
<img width="223" height="461" alt="스크린샷 2026-02-19 오전 1 40 07" src="https://github.com/user-attachments/assets/cb5132c8-e133-4c78-92d6-be6781c55539" />


## 📋 추후 진행 상황
- iPhone 13 mini 디바이스 기준 레이아웃 점검 및 보완
 
## 📌 리뷰 포인트
[ 어떤 부분을 잘 체크해야하는지 작성해주세요 ]



## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

closed #71 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 내부 코드 구조 개선으로 안정성 향상

**사용자 영향 없음**: 이 업데이트는 내부 코드 최적화이며 사용자가 인식할 수 있는 변경 사항은 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->